### PR TITLE
Change sandbox URL to test-api according to TW API documentation

### DIFF
--- a/lib/transfer_wise.rb
+++ b/lib/transfer_wise.rb
@@ -30,7 +30,7 @@ module TransferWise
     attr_accessor :access_token
 
     def api_base
-      @api_base ||= "https://#{mode == 'live' ? 'api' : 'test-restgw'}.transferwise.com"
+      @api_base ||= "https://#{mode == 'live' ? 'api' : 'test-api'}.transferwise.com"
     end
   end
 end


### PR DESCRIPTION
According to TW API documentation, URL has changed: https://api-docs.transferwise.com/v1/helpful/changelog