### PR TITLE
Enable support for the Borderless API

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,4 +147,61 @@ transfer = TransferWise::Transfer.create(transfer_request, {access_token: access
 
 ```
 
-Transfer object is created in transfer wise website. You can go there and make payments to complete the transfer.
+The Transfer object is created via the TransferWise website. You can go there and make payments to complete the transfer.
+
+# TransferWise Borderless Account
+A Borderless Account is a "virtual" bank account that you can control via the TransferWise API, to send funds to external bank accounts (across borders), as well as download statements and view the current balance.
+
+## Borderless Accounts
+https://api-docs.transferwise.com/v1/borderless-account/search-account-by-user-profile
+
+Get all the borderless accounts given a `profileId`
+
+```ruby
+account_request = { profileId: 1234567 }
+account = TransferWise::BorderlessAccount.list(nil, { 'params' => account_request })
+```
+
+## Borderless Account
+https://api-docs.transferwise.com/v1/borderless-account/get-available-balances
+
+Get a borderless account given a `borderlessAccountId`
+
+```ruby
+borderlessAccountId = 123
+account = TransferWise::BorderlessAccount.get(borderlessAccountId)
+```
+
+## Transactions
+https://api-docs.transferwise.com/v1/borderless-account/get-account-statement
+
+Get all the transactions for an account given a `borderlessAccountId`
+
+```ruby
+borderlessAccountId = 123
+transactions = TransferWise::BorderlessAccount::Transaction.list(nil, { 'params' => { page: '5' } }, resource_id: borderlessAccountId)
+```
+
+## Statement
+https://api-docs.transferwise.com/v1/borderless-account/get-statement
+
+Get a borderless account statement for a given currency
+
+```ruby
+query_string = {
+  profileId: 1234567,
+  currency: 'GBP',
+  startDate: '2017-12-01',
+  endDate: '2017-12-07'
+}
+statement = TransferWise::BorderlessAccount::Statement.list(nil, { 'params' => query_string })
+```
+
+## Currencies
+https://api-docs.transferwise.com/v1/borderless-account/available-currencies
+
+Get a list of available currencies for your balances
+
+```ruby
+TransferWise::BorderlessAccount::BalanceCurrency.list
+```

--- a/lib/transfer_wise.rb
+++ b/lib/transfer_wise.rb
@@ -19,6 +19,10 @@ require 'transfer_wise/account'
 require 'transfer_wise/transfer'
 require 'transfer_wise/util'
 require 'transfer_wise/request'
+require 'transfer_wise/borderless_account'
+require 'transfer_wise/borderless_account/balance_currency'
+require 'transfer_wise/borderless_account/statement'
+require 'transfer_wise/borderless_account/transaction'
 
 # Errors
 require 'transfer_wise/transfer_wise_error'

--- a/lib/transfer_wise/api_resource.rb
+++ b/lib/transfer_wise/api_resource.rb
@@ -2,6 +2,8 @@ module TransferWise
   class APIResource
     include TransferWise::TransferWiseObject
 
+    API_VERSION = 'v1'.freeze
+
     def self.class_name
       self.name.split('::')[-1]
     end
@@ -10,20 +12,20 @@ module TransferWise
       "#{collection_url}/#{resource_id}"
     end
 
-    def self.collection_url
+    def self.collection_url(resource_id = nil)
       if self == APIResource
         raise NotImplementedError.new('APIResource is an abstract class. You should perform actions on its subclasses (Account, Transfer, etc.)')
       end
-      "/v1/#{CGI.escape(class_name.downcase)}s"
+      "/#{API_VERSION}/#{CGI.escape(class_name.downcase)}s"
     end
 
-    def self.create(params={}, opts={})
+    def self.create(params = {}, opts = {})
       response = TransferWise::Request.request(:post, collection_url, params, opts)
       convert_to_transfer_wise_object(response)
     end
 
-    def self.list(filters = {}, headers = {})
-      response = TransferWise::Request.request(:get, collection_url, filters, headers)
+    def self.list(filters = {}, headers = {}, resource_id: nil)
+      response = TransferWise::Request.request(:get, collection_url(resource_id), filters, headers)
       convert_to_transfer_wise_object(response)
     end
 

--- a/lib/transfer_wise/borderless_account.rb
+++ b/lib/transfer_wise/borderless_account.rb
@@ -1,0 +1,7 @@
+module TransferWise
+  class BorderlessAccount < APIResource
+    def self.collection_url(resource_id = nil)
+      "/#{API_VERSION}/borderless-accounts"
+    end
+  end
+end

--- a/lib/transfer_wise/borderless_account/balance_currency.rb
+++ b/lib/transfer_wise/borderless_account/balance_currency.rb
@@ -1,0 +1,7 @@
+module TransferWise
+  class BorderlessAccount::BalanceCurrency < APIResource
+    def self.collection_url(resource_id = nil)
+      "/#{API_VERSION}/borderless-accounts/balance-currencies"
+    end
+  end
+end

--- a/lib/transfer_wise/borderless_account/statement.rb
+++ b/lib/transfer_wise/borderless_account/statement.rb
@@ -1,0 +1,7 @@
+module TransferWise
+  class BorderlessAccount::Statement < APIResource
+    def self.collection_url(resource_id = nil)
+      "/#{API_VERSION}/borderless-accounts/statement"
+    end
+  end
+end

--- a/lib/transfer_wise/borderless_account/transaction.rb
+++ b/lib/transfer_wise/borderless_account/transaction.rb
@@ -1,0 +1,7 @@
+module TransferWise
+  class BorderlessAccount::Transaction < APIResource
+    def self.collection_url(resource_id = nil)
+      "/#{API_VERSION}/borderless-accounts/#{resource_id}/transactions"
+    end
+  end
+end

--- a/lib/transfer_wise/request.rb
+++ b/lib/transfer_wise/request.rb
@@ -1,6 +1,5 @@
 module TransferWise
   class Request
-
     def self.api_url(url = '')
       TransferWise.api_base + url
     end
@@ -100,6 +99,5 @@ module TransferWise
         http_headers: resp.headers
       }
     end
-
   end
 end


### PR DESCRIPTION
Enable support for the TransferWise Borderless Accounts API, including the ability to retrieve all statements and account details.