### PR TITLE
Add the new Sandbox URL

### DIFF
--- a/lib/transfer_wise.rb
+++ b/lib/transfer_wise.rb
@@ -34,7 +34,7 @@ module TransferWise
     attr_accessor :access_token
 
     def api_base
-      @api_base ||= "https://#{mode == 'live' ? 'api' : 'test-api'}.transferwise.com"
+      @api_base ||= mode == 'live' ? 'https://api.transferwise.com' : 'https://api.sandbox.transferwise.tech'
     end
   end
 end


### PR DESCRIPTION
There's a new API base for the sandbox application.

Note, the authorize action requires a different URL in sandbox (https://sandbox.transferwise.tech), but in production requires https://api.transferwise.com still.