### PR TITLE
Adding fund method for Transfers and handle 409 error

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,13 @@ The Transfer object is created via the TransferWise website. You can go there an
 # TransferWise Borderless Account
 A Borderless Account is a "virtual" bank account that you can control via the TransferWise API, to send funds to external bank accounts (across borders), as well as download statements and view the current balance.
 
+
+## Fund your transfer from your borderless account available balance.
+
+```ruby
+transfer = TransferWise::Transfer.fund(transfer.id, { type: 'BALANCE' })
+```
+
 ## Borderless Accounts
 https://api-docs.transferwise.com/v1/borderless-account/search-account-by-user-profile
 

--- a/lib/transfer_wise/request.rb
+++ b/lib/transfer_wise/request.rb
@@ -58,7 +58,10 @@ module TransferWise
 
     def self.handle_api_error(resp)
       error_obj = parse(resp).with_indifferent_access
-      error_message = error_obj['error'].presence || error_obj['errors'].map{|e| e["message"]}.join(', ')
+      error_message = error_obj['error'].presence ||
+                      error_obj['errors']&.map{|e| e["message"]}&.join(', ') ||
+                      error_obj['errorCode'].presence
+
       if TransferWise::STATUS_CLASS_MAPPING.include?(resp.code)
         raise "TransferWise::#{TransferWise::STATUS_CLASS_MAPPING[resp.code]}".constantize.new(error_params(error_message, resp, error_obj))
       else

--- a/lib/transfer_wise/transfer.rb
+++ b/lib/transfer_wise/transfer.rb
@@ -1,4 +1,8 @@
 module TransferWise
   class Transfer < APIResource
+    def self.fund(resource_id, params, opts = {})
+      response = TransferWise::Request.request(:post, "#{resource_url(resource_id)}/payments", params, opts)
+      convert_to_transfer_wise_object(response)
+    end
   end
 end

--- a/lib/transfer_wise/transfer_wise_error.rb
+++ b/lib/transfer_wise/transfer_wise_error.rb
@@ -3,7 +3,8 @@ module TransferWise
   STATUS_CLASS_MAPPING = {
     400 => "InvalidRequestError",
     404 => "InvalidRequestError",
-    401 => "AuthenticationError"
+    401 => "AuthenticationError",
+    409 => "InvalidRequestError"
   }
 
   class TransferWiseError < StandardError
@@ -35,5 +36,4 @@ module TransferWise
 
   class ParseError < TransferWiseError
   end
-
 end


### PR DESCRIPTION
Adds a `fund` method to Transfer. Came across a new error code which was not being handled `409` Conflict so added.

This error is for when you're funding a Transfer that has already been funded.